### PR TITLE
Updated link to match the Godot version used by GDPaho (v3.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 A wrapping of paho cpp (https://www.eclipse.org/paho/) able to make MQTT clients in Godot, is a part of GDWired (https://github.com/GDWired).
 
-Works on Windows, macOS and Linux but there are only few functions exposed. The Godot build dependencies must be installed first, you can find everything about it here https://docs.godotengine.org/en/stable/development/compiling/index.html.
+Works on Windows, macOS and Linux but there are only few functions exposed. The Godot build dependencies must be installed first, you can find everything about it here https://docs.godotengine.org/en/3.5/development/compiling/index.html.
 
 Dependencies:
- - Godot build dependencies (https://docs.godotengine.org/en/stable/development/compiling/index.html)
+ - Godot build dependencies (https://docs.godotengine.org/en/3.5/development/compiling/index.html)
  - OpenSSL
    - Windows (https://slproweb.com/products/Win32OpenSSL.html)
    - Linux `apt install libssl-dev` or equivalent


### PR DESCRIPTION
When I checked the documentation, the link originally provided leads to the official Godot docs about compiling for latest Godot version (+v4.x).
Nevertheless, GDPaho is oriented to be used with Godot v3.5, so I updated the link to point to the v3.5 docs.   

I consider this necessary because accessing to the latest doc and using the version switching option will point to a broken link:
![image](https://github.com/GDWired/GDPaho/assets/12192256/1614e0e8-1eb4-4666-b07f-42d149ebc55b)

Have a nice day! 😊